### PR TITLE
ci: add sem-version to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+on:
+  push:
+    branches:
+    - main
+    - rc
+    - beta
+    - hotfix
+    - "*.x"
+
+env:
+  FLUTTER_VERSION: '3.10.x'
+
+jobs:
+  sem-version:
+    name: SemVersion
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Sem-Version
+      id: sem-version
+      uses: shiipou/sem-version@beta
+      with:
+        ALLOW_FAILURE: false
+
+    outputs:
+      WILL_RELEASE: ${{ steps.sem-version.outputs.WILL_RELEASE }}
+      IS_PRE_RELEASE: ${{ steps.sem-version.outputs.IS_PRE_RELEASE }}
+      VERSION: ${{ steps.sem-version.outputs.VERSION }}
+
+  build:
+    name: Build
+    needs: [ sem-version ]
+    strategy:
+      matrix:
+        target: [ windows, linux, macos]
+        include:
+          - target: windows
+            runner: windows-latest
+          - target: linux
+            runner: ubuntu-latest
+          - target: macos
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
+    environment: ${{ github.ref_name }}
+    timeout-minutes: 10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install Flutter & Dependencies
+      uses: subosito/flutter-action@2.10.0
+      with:
+        flutter-version: ${{ env.flutter_version }}
+    - name: Build Flutter ${{ matrix.target }}
+      run: |
+        flutter build ${{ matrix.target }} --flavor ${{ github.ref_name }}
+
+    - name: Zip artifact
+      if: ${{ matrix.runner == 'windows-latest' }}
+      shell: pwsh
+      run: Compress-Archive "build/${{ matrix.target }}" "modmopet-${{ matrix.target }}.zip"
+    - name: Zip artifact
+      if: ${{ matrix.os != 'windows' }}
+      shell: bash
+      run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.target }}"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: modmopet-${{ matrix.target }}
+        path: modmopet-${{ matrix.target }}.*
+
+  release:
+    name: Release
+    needs: [ build, sem-version ]
+    runs-on: ubuntu-latest
+    if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
+    environment: ${{ github.ref_name }}
+    timeout-minutes: 2
+    steps:
+    - name: download-artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: artifacts/
+
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: needs.sem-version.outputs.WILL_RELEASE == 'true'
+      run: |
+        ARGS='--generate-notes'
+        if [ -z "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ]; then
+          ARGS='$ARGS --latest'
+        fi
+        gh release create "v${{ needs.sem-version.outputs.VERSION }}" $ARGS ./artifacts/*


### PR DESCRIPTION
This PR will automate the creations of a release,
You need to follow [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/) rules to know what release will be produced by the CI.

It's powerfull and don't really need any action from you than following conventional-commits and working in PR.
Pushing on the main branch mean of creating a new release. So making a Pr to the main branch will create a stable release.
Making a PR to beta branch will make an unstable release.
Pushing to dev branch won't make a release

I did 2 PR for this functionality.
So you can choose the one you need.

https://github.com/modmopet/modmopet/pull/2 will use the node tool semantic-release to find the tag to create
https://github.com/modmopet/modmopet/pull/3 will use git commands to find the tag to create