### PR TITLE
ci: add sem-version to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,13 @@ jobs:
         include:
           - target: windows
             runner: windows-latest
-            artifact: windows/
+            artifact: windows/runner/Release/*
           - target: linux
             runner: ubuntu-latest
-            artifact: linux/
+            artifact: linux/x64/release/bundle/*
           - target: macos
             runner: macos-latest
-            artifact: macos/
+            artifact: macos/Build/Product/Release/ModMopet.app
     runs-on: ${{ matrix.runner }}
     if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
     environment: ${{ github.ref_name }}
@@ -82,8 +82,7 @@ jobs:
       
     - name: Build Flutter ${{ matrix.target }}
       run: |
-        flutter build ${{ matrix.target }}
-
+        make build ${{ matrix.target }}
 
     - name: Zip artifact
       if: ${{ matrix.runner == 'windows-latest' }}
@@ -92,7 +91,7 @@ jobs:
     - name: Zip artifact
       if: ${{ matrix.runner != 'windows-latest' }}
       shell: bash
-      run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.artifact }}"
+      run: tar -C "build/$(dirname ${{ matrix.artifact }})/" -czf "modmopet-${{ matrix.target }}.tar.gz" "$(basename ${{ matrix.artifact }})"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3
@@ -115,7 +114,7 @@ S
 
     - name: Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: needs.sem-version.outputs.WILL_RELEASE == 'true'
       run: |
         ARGS="--repo ${{ github.repository }} --target ${{ github.sha }} --generate-notes"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,4 +117,4 @@ jobs:
         if [ -z "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ]; then
           ARGS="$ARGS --prerelease"
         fi
-        gh release create $ARGS v${{ needs.sem-version.outputs.VERSION }} ./artifacts/*
+        gh release create $ARGS v${{ needs.sem-version.outputs.VERSION }} ./artifacts/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,8 +113,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: needs.sem-version.outputs.WILL_RELEASE == 'true'
       run: |
-        ARGS='--repo ${{ github.repository }} --target ${{ github.sha }} --generate-notes'
+        gh auth login --with-token < <(echo "${{ secrets.GH_TOKEN }}")
+        ARGS="--repo ${{ github.repository }} --target ${{ github.sha }} --generate-notes"
         if [ -z "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ]; then
-          ARGS='$ARGS --latest'
+          ARGS="$ARGS --prerelease"
         fi
-        gh release create "v${{ needs.sem-version.outputs.VERSION }}" $ARGS ./artifacts/*
+        gh release create $ARGS v${{ needs.sem-version.outputs.VERSION }} ./artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,9 @@ jobs:
 
     - name: Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       if: needs.sem-version.outputs.WILL_RELEASE == 'true'
       run: |
-        gh auth login --with-token < <(echo "${{ secrets.GH_TOKEN }}")
         ARGS="--repo ${{ github.repository }} --target ${{ github.sha }} --generate-notes"
         if [ -z "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ]; then
           ARGS="$ARGS --prerelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,13 @@ jobs:
         include:
           - target: windows
             runner: windows-latest
-            artifact: windows/runner/Release/*
+            artifact: build/windows/runner/Release/*
           - target: linux
             runner: ubuntu-latest
-            artifact: linux/x64/release/bundle/*
+            artifact: build/linux/x64/release/bundle/*
           - target: macos
             runner: macos-latest
-            artifact: macos/Build/Product/Release/ModMopet.app
+            artifact: build/macos/Build/Product/Release/ModMopet.app
     runs-on: ${{ matrix.runner }}
     if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
     environment: ${{ github.ref_name }}
@@ -87,11 +87,11 @@ jobs:
     - name: Zip artifact
       if: ${{ matrix.runner == 'windows-latest' }}
       shell: pwsh
-      run: Compress-Archive "build/${{ matrix.artifact }}" "modmopet-${{ matrix.target }}.zip"
+      run: Compress-Archive "${{ matrix.artifact }}" "modmopet-${{ matrix.target }}.zip"
     - name: Zip artifact
       if: ${{ matrix.runner != 'windows-latest' }}
       shell: bash
-      run: tar -C "build/$(dirname ${{ matrix.artifact }})/" -czf "modmopet-${{ matrix.target }}.tar.gz" "$(basename ${{ matrix.artifact }})"
+      run: tar -C "$(dirname ${{ matrix.artifact }})/" -czf "modmopet-${{ matrix.target }}.tar.gz" "$(basename ${{ matrix.artifact }})"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+on:
+  push:
+    branches:
+    - main
+    - rc
+    - beta
+    - hotfix
+    - "*.x"
+
+env:
+  FLUTTER_VERSION: '3.10.x'
+
+jobs:
+  sem-version:
+    name: SemVersion
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Sem-Version
+      id: sem-version
+      uses: shiipou/sem-version@beta
+      with:
+        ALLOW_FAILURE: false
+
+    outputs:
+      WILL_RELEASE: ${{ steps.sem-version.outputs.WILL_RELEASE }}
+      IS_PRE_RELEASE: ${{ steps.sem-version.outputs.IS_PRE_RELEASE }}
+      VERSION: ${{ steps.sem-version.outputs.VERSION }}
+
+  build:
+    name: Build
+    needs: [ sem-version ]
+    strategy:
+      matrix:
+        target: [ windows, linux, macos]
+        include:
+          - target: windows
+            runner: windows-latest
+          - target: linux
+            runner: ubuntu-latest
+          - target: macos
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
+    environment: ${{ github.ref_name }}
+    timeout-minutes: 10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install Flutter & Dependencies
+      uses: subosito/flutter-action@v2.10.0
+      with:
+        flutter-version: ${{ env.flutter_version }}
+    - name: Install Ninja
+      uses: lukka/get-cmake@latest
+      with:
+        ninjaVersion: latest
+    - name: Build Flutter ${{ matrix.target }}
+      run: |
+        flutter build ${{ matrix.target }}
+
+    - name: Zip artifact
+      if: ${{ matrix.runner == 'windows-latest' }}
+      shell: pwsh
+      run: Compress-Archive "build/${{ matrix.target }}" "modmopet-${{ matrix.target }}.zip"
+    - name: Zip artifact
+      if: ${{ matrix.os != 'windows' }}
+      shell: bash
+      run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.target }}"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: modmopet-${{ matrix.target }}
+        path: modmopet-${{ matrix.target }}.*
+
+  release:
+    name: Release
+    needs: [ build, sem-version ]
+    runs-on: ubuntu-latest
+    if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
+    environment: ${{ github.ref_name }}
+    timeout-minutes: 2
+    steps:
+    - name: download-artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: artifacts/
+
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: needs.sem-version.outputs.WILL_RELEASE == 'true'
+      run: |
+        ARGS='--generate-notes'
+        if [ -z "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ]; then
+          ARGS='$ARGS --latest'
+        fi
+        gh release create "v${{ needs.sem-version.outputs.VERSION }}" $ARGS ./artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     - main
     - rc
     - beta
+    - nightly
     - hotfix
     - "*.x"
 
@@ -25,6 +26,7 @@ jobs:
       uses: shiipou/sem-version@beta
       with:
         ALLOW_FAILURE: false
+        PRERELEASE_BRANCHES_REGEX: '^(rc|beta|nightly|hotfix)$'
 
     outputs:
       WILL_RELEASE: ${{ steps.sem-version.outputs.WILL_RELEASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       shell: pwsh
       run: Compress-Archive "build/${{ matrix.target }}" "modmopet-${{ matrix.target }}.zip"
     - name: Zip artifact
-      if: ${{ matrix.runner != 'windows' }}
+      if: ${{ matrix.runner != 'windows-latest' }}
       shell: bash
       run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.target }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,13 @@ jobs:
         include:
           - target: windows
             runner: windows-latest
+            artifact: windows/
           - target: linux
             runner: ubuntu-latest
+            artifact: linux/
           - target: macos
             runner: macos-latest
+            artifact: macos/
     runs-on: ${{ matrix.runner }}
     if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
     environment: ${{ github.ref_name }}
@@ -85,18 +88,18 @@ jobs:
     - name: Zip artifact
       if: ${{ matrix.runner == 'windows-latest' }}
       shell: pwsh
-      run: Compress-Archive "build/${{ matrix.target }}" "modmopet-${{ matrix.target }}.zip"
+      run: Compress-Archive "build/${{ matrix.artifact }}" "modmopet-${{ matrix.target }}.zip"
     - name: Zip artifact
       if: ${{ matrix.runner != 'windows-latest' }}
       shell: bash
-      run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.target }}"
+      run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.artifact }}"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
         name: modmopet-${{ matrix.target }}
         path: modmopet-${{ matrix.target }}.*
-
+S
   release:
     name: Release
     needs: [ build, sem-version ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,17 +60,17 @@ jobs:
         cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
         architecture: x64 # optional, x64 or arm64
 
-    - name: Install Dependencies
+    - name: Install Dependencies (windows)
       if: ${{ matrix.runner == 'windows-latest' }}
       run: |
         flutter config --enable-windows-desktop
-    - name: Install Dependencies
+    - name: Install Dependencies (linux)
       if: ${{ matrix.runner == 'ubuntu-latest' }}
       run: |
         sudo apt-get update -y
         sudo apt-get install -y ninja-build libgtk-3-dev
         flutter config --enable-linux-desktop
-    - name: Install Dependencies
+    - name: Install Dependencies (macos)
       if: ${{ matrix.runner == 'macos-latest' }}
       run: |
         flutter config --enable-macos-desktop
@@ -113,7 +113,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: needs.sem-version.outputs.WILL_RELEASE == 'true'
       run: |
-        ARGS='--generate-notes'
+        ARGS='--repo ${{ github.repository }} --target ${{ github.sha }} --generate-notes'
         if [ -z "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ]; then
           ARGS='$ARGS --latest'
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       shell: pwsh
       run: Compress-Archive "build/${{ matrix.target }}" "modmopet-${{ matrix.target }}.zip"
     - name: Zip artifact
-      if: ${{ matrix.os != 'windows' }}
+      if: ${{ matrix.runner != 'windows' }}
       shell: bash
       run: tar -C "build/" -czf "modmopet-${{ matrix.target }}.tar.gz" "${{ matrix.target }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,17 +51,34 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install Flutter & Dependencies
+    - name: Install Flutter
       uses: subosito/flutter-action@v2.10.0
       with:
         flutter-version: ${{ env.flutter_version }}
-    - name: Install Ninja
-      uses: lukka/get-cmake@latest
-      with:
-        ninjaVersion: latest
+        cache: true
+        cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache
+        cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+        architecture: x64 # optional, x64 or arm64
+
+    - name: Install Dependencies
+      if: ${{ matrix.runner == 'windows-latest' }}
+      run: |
+        flutter config --enable-windows-desktop
+    - name: Install Dependencies
+      if: ${{ matrix.runner == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y ninja-build libgtk-3-dev
+        flutter config --enable-linux-desktop
+    - name: Install Dependencies
+      if: ${{ matrix.runner == 'macos-latest' }}
+      run: |
+        flutter config --enable-macos-desktop
+      
     - name: Build Flutter ${{ matrix.target }}
       run: |
         flutter build ${{ matrix.target }}
+
 
     - name: Zip artifact
       if: ${{ matrix.runner == 'windows-latest' }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build
+
+build:
+	TARGET=$(filter-out $@,$(MAKECMDGOALS))
+	flutter build $(TARGET)
+%:
+	@:


### PR DESCRIPTION
This PR will automate the creations of a release,
You need to follow [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/) rules to know what release will be produced by the CI.

It's powerfull and don't really need any action from you than following conventional-commits and working in PR.
Pushing on the main branch mean of creating a new release. So making a Pr to the main branch will create a stable release.
Making a PR to beta branch will make an unstable release.
Pushing to dev branch won't make a release

I did 2 PR for this functionality.
So you can choose the one you need.

https://github.com/modmopet/modmopet/pull/2 will use the node tool semantic-release to find the tag to create
https://github.com/modmopet/modmopet/pull/4 will use git commands to find the tag to create

It will look like this : [![Release](https://github.com/shiipou/modmopet/actions/workflows/release.yml/badge.svg?branch=beta&event=push)](https://github.com/shiipou/modmopet/actions/runs/5121071176)
![image](https://github.com/modmopet/modmopet/assets/38187238/54f43296-067f-4abd-a53a-d419a25b618c)
![image](https://github.com/modmopet/modmopet/assets/38187238/e3225ca4-1362-471f-a90b-c89c21624e33)

It generate a release note according to each PR that got submitted before the previous tag in the same history :
![image](https://github.com/modmopet/modmopet/assets/38187238/62406df5-c641-48d0-bba4-db596fe60984)
