### PR TITLE
build: fix Makefile had a wrong syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: build
 
+
+TARGET := $(filter-out build,$(MAKECMDGOALS))
+
 build:
-	TARGET=$(filter-out $@,$(MAKECMDGOALS))
 	flutter build $(TARGET) --dart-define=GITHUB_API_TOKEN=${APP_GITHUB_API_TOKEN}
 %:
 	@:


### PR DESCRIPTION
Vars in makefile was not placed a good place, and I didn't use the .PHONY argument but all the argument in the build command (What resulted as `flutter build build windows`)