### PR TITLE
ci: Build artifacts for all platforms (zip,deb,rpm,appimage,exe,msix,dmg)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             runner: ubuntu-latest
             artifacts: dist/*/*
           - platform: windows
-            targets: zip,exe
+            targets: zip,exe,msix
             runner: windows-latest
             artifacts: dist/*/*
           - platform: macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             runner: ubuntu-latest
             artifacts: dist/*/*
           - platform: windows
-            targets: zip,exe,msix
+            targets: zip,exe
             runner: windows-latest
             artifacts: dist/*/*
           - platform: macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     name: build-${{ matrix.platform }}
     needs: [get-version, get-build]
+    if: ${{ needs.get-version.outputs.will-release }}
     uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
     strategy:
       matrix:
@@ -56,8 +57,9 @@ jobs:
       artifacts: ${{ matrix.artifacts }}
 
   release:
-    needs: build
+    needs: [get-version, build]
     uses: shiipou/github-actions/.github/workflows/release.yml@1-fix-flutter-release-didnt-work
+    if: ${{ needs.get-version.outputs.will-release }}
     with:
       version:  ${{ needs.get-version.outputs.version }}
       changelogs: ${{ needs.get-version.outputs.changelogs }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     uses: shiipou/github-actions/.github/workflows/increment-variable.yml@1-fix-flutter-release-didnt-work
     with:
       variable-name: build_number
-    secrets: 
+    secrets:
       token: ${{ secrets.GH_TOKEN_WRITE_VARIABLES }}
   build:
     name: build-${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,4 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: artifacts/*/*/*
+      assets: "artifacts/*/*/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,15 @@ jobs:
           - platform: linux
             targets: zip,deb,rpm,appimage
             runner: ubuntu-latest
-            artifacts: dist/*/*.{zip,deb,rpm,AppImage}
+            artifacts: dist/*/*
           - platform: windows
             targets: zip,exe,msix
             runner: windows-latest
-            artifacts: dist/*/*.{zip,exe,msix}
+            artifacts: dist/*/*
           - platform: macos
             targets: zip,dmg
             runner: macos-latest
-            artifacts: dist/*/*.{zip,dmg}
+            artifacts: dist/*/*
     with:
       package-name: ModMopet
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,4 +78,4 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: ${{ github.workspace }}/artifacts/*/*/*
+      assets: $GITHUB_WORKSPACE/artifacts/*/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,4 +78,3 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: $GITHUB_WORKSPACE/artifacts/*/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,22 +55,9 @@ jobs:
       targets: ${{ matrix.targets }}
       runner: ${{ matrix.runner }}
       artifacts: ${{ matrix.artifacts }}
-
-  artifact-paths:
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ needs.get-version.outputs.will-release }}
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: artifacts/
-      - name: list artifacts
-        run: |
-          ls -lia artifacts/*/*/
       
   release:
-    needs: [get-version, build, artifact-paths]
+    needs: [get-version, build]
     uses: shiipou/github-actions/.github/workflows/release.yml@main
     if: ${{ needs.get-version.outputs.will-release }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,4 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: artifacts/
+      assets: artifacts/*/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       variable-name: build-number
     secrets: 
-      token: GH_TOKEN_WRITE_VARIABLES
+      token: ${{ secrets.GH_TOKEN_WRITE_VARIABLES }}
   build:
     needs: [get-version, get-build]
     uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,4 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: artifacts/*/*
+      assets: artifacts/*/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,128 +12,29 @@ on:
 env:
   FLUTTER_VERSION: '3.10.x'
 
+permissions:
+  contents: write
+
 jobs:
-  sem-version:
-    name: SemVersion
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Sem-Version
-      id: sem-version
-      uses: shiipou/sem-version@beta
-      with:
-        ALLOW_FAILURE: false
-        PRERELEASE_BRANCHES_REGEX: '^(rc|beta|nightly|hotfix)$'
-
-    outputs:
-      WILL_RELEASE: ${{ steps.sem-version.outputs.WILL_RELEASE }}
-      IS_PRE_RELEASE: ${{ steps.sem-version.outputs.IS_PRE_RELEASE }}
-      VERSION: ${{ steps.sem-version.outputs.VERSION }}
-      CHANGELOG: ${{ steps.sem-version.outputs.CHANGELOG }}
-
+  get-version:
+    uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
+    with:
+      prerelease-branches: rc,beta,nightly,hotfix
+  get-build:
+    uses: shiipou/github-actions/.github/workflows/increment-variable.yml@1-fix-flutter-release-didnt-work
+    with:
+      variable-name: build-number
   build:
-    name: Build
-    needs: [ sem-version ]
-    strategy:
-      matrix:
-        target: [ windows, linux, macos]
-        include:
-          - target: windows
-            runner: windows-latest
-            artifact: build/windows/runner/Release
-          - target: linux
-            runner: ubuntu-latest
-            artifact: build/linux/x64/release/bundle
-          - target: macos
-            runner: macos-latest
-            artifact: build/macos/Build/Products/Release/ModMopet.app
-    runs-on: ${{ matrix.runner }}
-    if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
-    environment: ${{ github.ref_name }}
-    timeout-minutes: 20
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Install Flutter
-      uses: subosito/flutter-action@v2.10.0
-      with:
-        flutter-version: ${{ env.flutter_version }}
-        cache: true
-        cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache
-        cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
-        architecture: x64 # optional, x64 or arm64
-
-    - name: Install Dependencies (windows)
-      if: ${{ matrix.runner == 'windows-latest' }}
-      run: |
-        flutter config --enable-windows-desktop
-    - name: Install Dependencies (linux)
-      if: ${{ matrix.runner == 'ubuntu-latest' }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y ninja-build libgtk-3-dev
-        flutter config --enable-linux-desktop
-    - name: Install Dependencies (macos)
-      if: ${{ matrix.runner == 'macos-latest' }}
-      run: |
-        flutter config --enable-macos-desktop
-
-    - name: Build Flutter ${{ matrix.target }}
-      env:
-        VERSION: ${{ needs.sem-version.outputs.VERSION }}
-        GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
-        GH_APP_ID: ${{ secrets.GH_APP_ID }}
-        GH_INSTALLMENT_ID: ${{ secrets.GH_INSTALLMENT_ID }}
-        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        SENTRY_TRACE_SAMPLE_RATE: ${{ vars.SENTRY_TRACE_SAMPLE_RATE }}
-      run: |
-        make build ${{ matrix.target }}
-
-    - name: Zip artifact (Windows)
-      if: ${{ matrix.runner == 'windows-latest' }}
-      shell: pwsh
-      run: Compress-Archive "${{ matrix.artifact }}" "modmopet-${{ matrix.target }}.zip"
-    - name: Zip artifact (Linux)
-      if: ${{ matrix.runner == 'ubuntu-latest' }}
-      shell: bash
-      run: tar -C "$(dirname ${{ matrix.artifact }})" -czf "modmopet-${{ matrix.target }}.tar.gz" "$(basename ${{ matrix.artifact }})" --transform "s/$(basename ${{ matrix.artifact }})/ModMopet/"
-    - name: Zip artifact (MacOS)
-      if: ${{ matrix.runner == 'macos-latest' }}
-      shell: bash
-      run: tar -C "$(dirname ${{ matrix.artifact }})" -czf "modmopet-${{ matrix.target }}.tar.gz" "$(basename ${{ matrix.artifact }})"
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: modmopet-${{ matrix.target }}
-        path: modmopet-${{ matrix.target }}.*
+    needs: get-version
+    uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
+    with:
+      package-name: ModMopet
+      version: ${{ needs.get-version.outputs.version }}
+      build: ${{ needs.get-build.outputs.value }}
   release:
-    name: Release
-    needs: [ build, sem-version ]
-    runs-on: ubuntu-latest
-    if: ${{ needs.sem-version.outputs.WILL_RELEASE == 'true' }}
-    environment: ${{ github.ref_name }}
-    permissions:
-      contents: write
-    timeout-minutes: 2
-    steps:
-    - name: download-artifacts
-      uses: actions/download-artifact@v3
-      with:
-        path: artifacts/
-    - name: Release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: needs.sem-version.outputs.WILL_RELEASE == 'true'
-      run: |
-        changelog_file=$(mktemp)
-        echo "${{ needs.sem-version.outputs.CHANGELOG }}" >> "$changelog_file"
-
-        ARGS="--repo ${{ github.repository }} --target ${{ github.sha }} -F $changelog_file"
-        if [[ "${{ needs.sem-version.outputs.IS_PRE_RELEASE }}" ==  "true" ]]; then
-          ARGS="$ARGS --prerelease"
-        fi
-        gh release create $ARGS v${{ needs.sem-version.outputs.VERSION }} ./artifacts/*/*
+    needs: build
+    uses: shiipou/github-actions/.github/workflows/release.yml@1-fix-flutter-release-didnt-work
+    with:
+      prerelease-branches: rc,beta,nightly,hotfix
+      download-artifacts: true
+      assets: artifacts/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       variable-name: build-number
   build:
-    needs: get-version
+    needs: [get-version, get-build]
     uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
     with:
       package-name: ModMopet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,7 @@ jobs:
           path: artifacts/
       - name: list artifacts
         run: |
-          ls -lia artifacts/
-          ls -lia artifacts/*/
           ls -lia artifacts/*/*/
-          ls -lia artifacts/*/*/*/
       
   release:
     needs: [get-version, build, artifact-paths]
@@ -81,4 +78,4 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: artifacts/*/*/*
+      assets: ${{ github.workspace }}/artifacts/*/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,22 @@ jobs:
   build:
     needs: [get-version, get-build]
     uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
+    strategy:
+      matrix:
+        platform: [ windows, linux, macos ]
+        include:
+          - platform: linux
+            targets: zip,deb,rpm,appimage
+            runner: ubuntu-latest
+            artifacts: dist/linux/*.{zip,deb,rpm,AppImage}
+          - platform: windows
+            targets: zip,exe,msix
+            runner: windows-latest
+            artifacts: dist/windows/*.{zip,exe,msix}
+          - platform: macos
+            targets: zip,dmg
+            runner: macos-latest
+            artifacts: dist/macos/*.{zip,dmg}
     with:
       package-name: ModMopet
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ env:
 
 permissions:
   contents: write
-  actions: write
-  repository-projects: write
 
 jobs:
   get-version:
@@ -49,6 +47,9 @@ jobs:
       package-name: ModMopet
       version: ${{ needs.get-version.outputs.version }}
       build: ${{ needs.get-build.outputs.value }}
+    secrets: 
+      GITHUB_TOKEN: GH_TOKEN_WRITE_VARIABLES
+
   release:
     needs: build
     uses: shiipou/github-actions/.github/workflows/release.yml@1-fix-flutter-release-didnt-work

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,4 @@ jobs:
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: "artifacts/*/*/"
+      assets: "artifacts/*/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
     needs: build
     uses: shiipou/github-actions/.github/workflows/release.yml@1-fix-flutter-release-didnt-work
     with:
-      prerelease-branches: rc,beta,nightly,hotfix
+      version:  ${{ needs.get-version.outputs.version }}
+      changelogs: ${{ needs.get-version.outputs.changelogs }}
+      is-prerelease: ${{ needs.get-version.outputs.is-prerelease }}
       download-artifacts: true
       assets: artifacts/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,15 @@ jobs:
           - platform: linux
             targets: zip,deb,rpm,appimage
             runner: ubuntu-latest
-            artifacts: dist/linux/*.{zip,deb,rpm,AppImage}
+            artifacts: dist/*/*.{zip,deb,rpm,AppImage}
           - platform: windows
             targets: zip,exe,msix
             runner: windows-latest
-            artifacts: dist/windows/*.{zip,exe,msix}
+            artifacts: dist/*/*.{zip,exe,msix}
           - platform: macos
             targets: zip,dmg
             runner: macos-latest
-            artifacts: dist/macos/*.{zip,dmg}
+            artifacts: dist/*/*.{zip,dmg}
     with:
       package-name: ModMopet
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,24 @@ jobs:
       runner: ${{ matrix.runner }}
       artifacts: ${{ matrix.artifacts }}
 
+  artifact-paths:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ needs.get-version.outputs.will-release }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts/
+      - name: list artifacts
+        run: |
+          ls -lia artifacts/
+          ls -lia artifacts/*/
+          ls -lia artifacts/*/*/
+          ls -lia artifacts/*/*/*/
+      
   release:
-    needs: [get-version, build]
+    needs: [get-version, build, artifact-paths]
     uses: shiipou/github-actions/.github/workflows/release.yml@main
     if: ${{ needs.get-version.outputs.will-release }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     uses: shiipou/github-actions/.github/workflows/increment-variable.yml@1-fix-flutter-release-didnt-work
     with:
       variable-name: build-number
+    secrets: 
+      token: GH_TOKEN_WRITE_VARIABLES
   build:
     needs: [get-version, get-build]
     uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
@@ -47,8 +49,6 @@ jobs:
       package-name: ModMopet
       version: ${{ needs.get-version.outputs.version }}
       build: ${{ needs.get-build.outputs.value }}
-    secrets: 
-      token: GH_TOKEN_WRITE_VARIABLES
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   get-version:
-    uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
+    uses: shiipou/github-actions/.github/workflows/get-version.yml@1-fix-flutter-release-didnt-work
     with:
       prerelease-branches: rc,beta,nightly,hotfix
   get-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     secrets: 
       token: ${{ secrets.GH_TOKEN_WRITE_VARIABLES }}
   build:
+    name: build-${{ matrix.platform }}
     needs: [get-version, get-build]
     uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
     strategy:
@@ -49,6 +50,10 @@ jobs:
       package-name: ModMopet
       version: ${{ needs.get-version.outputs.version }}
       build: ${{ needs.get-build.outputs.value }}
+      platform: ${{ matrix.platform }}
+      targets: ${{ matrix.targets }}
+      runner: ${{ matrix.runner }}
+      artifacts: ${{ matrix.artifacts }}
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ permissions:
 
 jobs:
   get-version:
-    uses: shiipou/github-actions/.github/workflows/get-version.yml@1-fix-flutter-release-didnt-work
+    uses: shiipou/github-actions/.github/workflows/get-version.yml@main
     with:
       prerelease-branches: '^(rc|beta|nightly|hotfix)$'
   get-build:
-    uses: shiipou/github-actions/.github/workflows/increment-variable.yml@1-fix-flutter-release-didnt-work
+    uses: shiipou/github-actions/.github/workflows/increment-variable.yml@main
     with:
       variable-name: build_number
     secrets:
@@ -30,7 +30,7 @@ jobs:
     name: build-${{ matrix.platform }}
     needs: [get-version, get-build]
     if: ${{ needs.get-version.outputs.will-release }}
-    uses: shiipou/github-actions/.github/workflows/build-flutter.yml@1-fix-flutter-release-didnt-work
+    uses: shiipou/github-actions/.github/workflows/build-flutter.yml@main
     strategy:
       matrix:
         platform: [ windows, linux, macos ]
@@ -58,11 +58,11 @@ jobs:
 
   release:
     needs: [get-version, build]
-    uses: shiipou/github-actions/.github/workflows/release.yml@1-fix-flutter-release-didnt-work
+    uses: shiipou/github-actions/.github/workflows/release.yml@main
     if: ${{ needs.get-version.outputs.will-release }}
     with:
       version:  ${{ needs.get-version.outputs.version }}
       changelogs: ${{ needs.get-version.outputs.changelogs }}
       is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
-      assets: "artifacts/*/*"
+      assets: artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       version: ${{ needs.get-version.outputs.version }}
       build: ${{ needs.get-build.outputs.value }}
     secrets: 
-      GITHUB_TOKEN: GH_TOKEN_WRITE_VARIABLES
+      token: GH_TOKEN_WRITE_VARIABLES
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
 permissions:
   contents: write
   actions: write
+  repository-projects: write
 
 jobs:
   get-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   get-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   get-version:
     uses: shiipou/github-actions/.github/workflows/get-version.yml@1-fix-flutter-release-didnt-work
     with:
-      prerelease-branches: rc,beta,nightly,hotfix
+      prerelease-branches: '^(rc|beta|nightly|hotfix)$'
   get-build:
     uses: shiipou/github-actions/.github/workflows/increment-variable.yml@1-fix-flutter-release-didnt-work
     with:
@@ -61,6 +61,6 @@ jobs:
     with:
       version:  ${{ needs.get-version.outputs.version }}
       changelogs: ${{ needs.get-version.outputs.changelogs }}
-      is-prerelease: ${{ needs.get-version.outputs.is-prerelease }}
+      is-prerelease: ${{ needs.get-version.outputs.is-prerelease == 'true' }}
       download-artifacts: true
       assets: artifacts/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       targets: ${{ matrix.targets }}
       runner: ${{ matrix.runner }}
       artifacts: ${{ matrix.artifacts }}
+      flutter-extra-args: --build-dart-define=MM_GITHUB_INSTALLMENT_ID=${GH_INSTALLMENT_ID} --build-dart-define=MM_GITHUB_APP_ID=${GH_APP_ID} --build-dart-define=MM_GITHUB_PRIVATE_KEY=${GH_PRIVATE_KEY} --build-dart-define=MM_SENTRY_DSN=${SENTRY_DSN} --build-dart-define=MM_SENTRY_TRACE_SAMPLE_RATE=${SENTRY_TRACE_SAMPLE_RATE}
       
   release:
     needs: [get-version, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   get-build:
     uses: shiipou/github-actions/.github/workflows/increment-variable.yml@1-fix-flutter-release-didnt-work
     with:
-      variable-name: build-number
+      variable-name: build_number
     secrets: 
       token: ${{ secrets.GH_TOKEN_WRITE_VARIABLES }}
   build:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-.PHONY: build
-
-
-TARGET := $(filter-out build,$(MAKECMDGOALS))
-
-build: $(TARGET)
-	flutter build $(TARGET) --build-name ${VERSION} --dart-define=MM_GITHUB_INSTALLMENT_ID=${GH_INSTALLMENT_ID} --dart-define=MM_GITHUB_APP_ID=${GH_APP_ID} --dart-define=MM_GITHUB_PRIVATE_KEY=${GH_PRIVATE_KEY} --dart-define=MM_SENTRY_DSN=${SENTRY_DSN} --dart-define=MM_SENTRY_TRACE_SAMPLE_RATE=${SENTRY_TRACE_SAMPLE_RATE} --dart-define=FLUTTER_BUILD_NUMBER=${BUILD_NUMBER} --dart-define=FLUTTER_BUILD_NAME=${VERSION}
-%:
-	@:

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -1,0 +1,28 @@
+display_name: ModMopet
+
+icon: assets/images/flutter_logo.png
+
+keywords:
+  - emulation
+  - mods
+  - game
+  - switch
+
+generic_name: ModMopet
+
+
+categories:
+  - Games
+
+startup_notify: true
+
+# You can specify the shared libraries that you want to bundle with your app
+#
+# flutter_distributor automatically detects the shared libraries that your app
+# depends on, but you can also specify them manually here.
+#
+# The following example shows how to bundle the libcurl library with your app.
+#
+# include:
+#   - libcurl.so.4
+include: []

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -12,7 +12,7 @@ generic_name: ModMopet
 
 
 categories:
-  - Games
+  - X-Game
 
 startup_notify: true
 

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -1,0 +1,23 @@
+display_name: ModMopet
+package_name: modmopet
+maintainer:
+  name: LiJianying
+  email: lijy91@foxmail.com
+priority: optional
+section: x11
+installed_size: 6604
+essential: false
+icon: assets/images/flutter_logo.png
+
+keywords:
+  - emulation
+  - mods
+  - game
+  - switch
+
+generic_name: ModMopet
+
+categories:
+  - Games
+
+startup_notify: true

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -18,6 +18,6 @@ keywords:
 generic_name: ModMopet
 
 categories:
-  - Games
+  - X-Game
 
 startup_notify: true

--- a/linux/packaging/rpm/make_config.yaml
+++ b/linux/packaging/rpm/make_config.yaml
@@ -1,0 +1,23 @@
+display_name: ModMopet
+
+icon: assets/images/flutter_logo.png
+
+summary: A really cool application
+group: Application/Emulator
+vendor: Kingkor Roy Tirtho
+packager: Kingkor Roy Tirtho
+packagerEmail: krtirtho@gmail.com
+license: GPLv3
+url: https://github.com/ModMopet/ModMopet
+keywords:
+  - games
+  - emulation
+  - mods
+  - switch
+
+generic_name: ModMopet
+
+categories:
+  - Games
+
+startup_notify: true

--- a/linux/packaging/rpm/make_config.yaml
+++ b/linux/packaging/rpm/make_config.yaml
@@ -18,6 +18,6 @@ keywords:
 generic_name: ModMopet
 
 categories:
-  - Games
+  - X-Game
 
 startup_notify: true

--- a/macos/packaging/dmg/make_config.yaml
+++ b/macos/packaging/dmg/make_config.yaml
@@ -1,0 +1,10 @@
+title: ModMopet
+contents:
+  - x: 448
+    y: 344
+    type: link
+    path: "/Applications"
+  - x: 192
+    y: 344
+    type: file
+    path: ModMopet.app

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -1,0 +1,10 @@
+# The value of AppId uniquely identifies this application.
+# Do not use the same AppId value in installers for other applications.
+app_id: 4FB521BA-98C0-43D0-8B74-891EA6D7B2E5
+publisher: ModMopet
+publisher_url: https://github.com/ModMopet/ModMopet
+display_name: ModMopet
+create_desktop_icon: true
+install_dir_name: ModMopet
+locales:
+  - en

--- a/windows/packaging/msix/make_config.yaml
+++ b/windows/packaging/msix/make_config.yaml
@@ -1,0 +1,3 @@
+display_name: ModMopet
+msix_version: 1.0.0.0
+logo_path: assets\images\flutter_logo.png


### PR DESCRIPTION
This PR add a completely new build procedure that make everything more thrustable.
That also add for end-users of the apps a build of the app for each platforms in multiple targets.
That mean,
- Linux users will now have choice between : zip, deb, rpm, or AppImage
- MacOS users will now have choice between : zip, or dmg
- Windows users will now have choice between : zip, exe, or msix

For developers that CI also introduce CI specific artifacts. That mean, you can download each artifact to test it locally when the commit on release/prerelease branch didn't produce a release. To download it, go in the actions, select your run, and you'll see artifacts at the bottom for each platforms.

That new CI is also needed for the next feature I'll develop, the Auto-Updater.

**Before merging: **
You must create the token with Read and Write access to actions variables scope.
And place it in the secret named `GH_TOKEN_WRITE_VARIABLES`